### PR TITLE
Feature: Add settings modal and persist settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,23 @@
 
 ### Kowloon Motor Bus and Long Win Bus Services
 
-The project makes use of 3 APIs from [Real time Arrival Data of Kowloon Motor Bus and Long Win Bus Services](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb) to get the estimated arrival time for a specific bus route at a particular bus stop.
+The project makes use of 5 APIs from [Real time Arrival Data of Kowloon Motor Bus and Long Win Bus Services](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb) to get the estimated arrival time for a specific bus route at a particular bus stop.
 
+- [Route Data](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb/resource/fd54acc3-4474-4620-8ff9-51c35cbe1c5f)
 - [Route-Stop Data](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb/resource/9fc22f3a-5eae-4df8-9346-ba3e32a4f90d)
 - [Stop Data](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb/resource/8f60fda1-5720-4dbc-a41f-fa1e20b9b35e)
+- [Route List Data](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb/resource/af2002f2-53f1-431d-bdc0-0e28db689c08)
 - [Stop ETA Data](https://data.gov.hk/en-data/dataset/hk-td-tis_21-etakmb/resource/16c76add-adca-4ec3-99c2-c22d1d593372)
 
 You can get all bus stops using [Stop List Data](https://data.etabus.gov.hk/v1/transport/kmb/stop)
 
 ### New Lantao Bus Company (1973) Limited
 
-The project makes use of 2 APIs from [Bus service of New Lantao Bus Company (1973) Limited (Second generation)](https://data.gov.hk/en-data/dataset/nlb-bus-nlb-bus-service-v2
+The project makes use of 3 APIs from [Bus service of New Lantao Bus Company (1973) Limited (Second generation)](https://data.gov.hk/en-data/dataset/nlb-bus-nlb-bus-service-v2
 ) to get the estimated arrival time for a specific bus route at a particular bus stop.
 
 - [Get list of all routes](https://www.nlb.com.hk/datagovhk/BusServiceOpenAPIDocumentation2.0.pdf)
+- [Get list of stops of a route](https://www.nlb.com.hk/datagovhk/BusServiceOpenAPIDocumentation2.0.pdf)
 - [Get estimated arrivals of a stop of a route](https://www.nlb.com.hk/datagovhk/BusServiceOpenAPIDocumentation2.0.pdf)
 
 It also makes use of a static js file (`nlb.js`) that contains all the bus stops.

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-[var(--color-bg)]">
-    <div id="app" class="container mx-auto font-exo"></div>
+  <body class="bg-[var(--color-bg)] font-exo">
+    <div id="app" class="container mx-auto"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,13 +37,14 @@ const app = {
   },
   methods: {
     async updateSetting(setting) {
-      console.log(setting);
+      console.log("Saving:" + setting);
       this.check.company = setting.company;
       this.check.busStop = setting.stop;
       this.check.route = setting.route;
       this.check.dir = setting.dir;
       this.check.serviceType = setting.serviceType;
 
+      // refresh data
       await this.updateRouteStopInfo();
       await this.updateAll();
     },
@@ -126,8 +127,8 @@ export default app;
         >
           @ {{ res.busStop?.name_en }} <br />
           <br />
-          # {{ res.route?.route }} <br />
-          // {{ res.route?.orig_en }} >> {{ res.route?.dest_en }}
+          # {{ res.route?.route }} // {{ res.route?.orig_en }} >>
+          {{ res.route?.dest_en }}
         </h1>
         <div
           class="flex flex-col md:flex-row md:justify-center md:items-center w-full"
@@ -171,8 +172,8 @@ export default app;
           </template>
         </div>
       </div>
+      <StationSettings title="Settings" @update-setting="updateSetting" />
     </div>
-    <StationSettings title="Settings" @update-setting="updateSetting" />
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script>
 import _ from "lodash";
-import { extractNumber, getEtaByCompany } from "./eta";
+import { extractNumber, getEtaByCompany, readSettingsFromStorage } from "./eta";
 import StationSettings from "./components/StationSettings.vue";
 
 const app = {
@@ -14,11 +14,16 @@ const app = {
       res: { route: null, busStop: null, etas: [] },
       lang: "en",
       check: {
-        company: "KMB",
-        busStop: "31072508CEF942C6",
-        route: "281A",
-        dir: "inbound",
-        serviceType: "1",
+        company: "",
+        busStop: "",
+        route: "",
+        dir: "",
+        serviceType: "",
+        // company: "KMB",
+        // busStop: "31072508CEF942C6",
+        // route: "281A",
+        // dir: "inbound",
+        // serviceType: "1",
         // company: "NLB",
         // busStop: "13",
         // route: "7",
@@ -36,10 +41,23 @@ const app = {
     };
   },
   methods: {
-    async updateSetting(setting) {
+    getSettingsFromStorage() {
+      return readSettingsFromStorage();
+    },
+    readSettings() {
+      const settings = readSettingsFromStorage();
+      if (settings) {
+        this.check.company = settings.company;
+        this.check.busStop = settings.busStop;
+        this.check.route = settings.route;
+        this.check.dir = settings.dir;
+        this.check.serviceType = settings.serviceType;
+      }
+    },
+    async updateSettings(setting) {
       console.log("Saving setting");
       this.check.company = setting.company;
-      this.check.busStop = setting.stop;
+      this.check.busStop = setting.busStop;
       this.check.route = setting.route;
       this.check.dir = setting.dir;
       this.check.serviceType = setting.serviceType;
@@ -104,9 +122,11 @@ const app = {
     },
   },
   created: async function () {
-    await this.updateRouteStopInfo();
+    // await this.updateRouteStopInfo();
   },
   mounted: async function () {
+    this.readSettings();
+    await this.updateRouteStopInfo();
     await this.updateAll();
     setInterval(async () => {
       await this.updateAll();
@@ -172,7 +192,10 @@ export default app;
           </template>
         </div>
       </div>
-      <StationSettings title="Settings" @update-setting="updateSetting" />
+      <StationSettings
+        :settings="this.getSettingsFromStorage()"
+        @update-settings="updateSettings"
+      />
     </div>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,7 +37,7 @@ const app = {
   },
   methods: {
     async updateSetting(setting) {
-      console.log("Saving:" + setting);
+      console.log("Saving setting");
       this.check.company = setting.company;
       this.check.busStop = setting.stop;
       this.check.route = setting.route;

--- a/src/App.vue
+++ b/src/App.vue
@@ -101,7 +101,7 @@ export default app;
     <div class="bg-[var(--color-bg)] text-[var(--color-text)] p-8">
       <div class="flex flex-col h-full items-center justify-center py-8">
         <h1
-          class="text-3xl font-bold mb-4 w-full"
+          class="text-lg md:text-4xl font-bold mb-4 w-full"
           style="color: var(--color-primary)"
         >
           @ {{ res.busStop?.name_en }} <br />
@@ -120,13 +120,13 @@ export default app;
               >
                 <div class="flex flex-col items-center justify-center h-full">
                   <div
-                    class="text-6xl font-bold mb-2"
+                    class="text-4xl md:text-6xl font-bold mb-2"
                     style="color: var(--color-text)"
                   >
                     {{ eta.etaStr }}
                   </div>
                   <div
-                    class="text-lg font-medium"
+                    class="text-lg md:text-xl font-medium"
                     style="color: var(--color-text)"
                   >
                     Arriving in {{ eta.fromNow }}

--- a/src/App.vue
+++ b/src/App.vue
@@ -81,42 +81,47 @@ const app = {
       };
     },
     async updateRouteStopInfo() {
-      this.res.route = await getEtaByCompany(this.check.company).getRoute(
-        this.check.route,
-        this.check.dir,
-        this.check.serviceType
-      );
-      this.res.busStop = await getEtaByCompany(this.check.company).getStop(
-        this.check.busStop
-      );
+      if (this.check.company) {
+        this.res.route = await getEtaByCompany(this.check.company).getRoute(
+          this.check.route,
+          this.check.dir,
+          this.check.serviceType
+        );
+        this.res.busStop = await getEtaByCompany(this.check.company).getStop(
+          this.check.busStop
+        );
+      }
     },
     async updateAll() {
       const allEtas = [];
-      this.now = new Date().toLocaleTimeString();
-      this.isLoading = true;
 
-      try {
-        const obj = await this.getRouteBusStopEta(
-          this.check.company,
-          this.check.busStop,
-          this.check.route,
-          this.check.dir,
-          this.check.serviceType,
-          this.lang
-        );
-        allEtas.push(...obj.etas);
-      } catch (error) {
-        console.log(error);
+      if (this.check.company && this.check.route && this.check.busStop) {
+        this.now = new Date().toLocaleTimeString();
+        this.isLoading = true;
+
+        try {
+          const obj = await this.getRouteBusStopEta(
+            this.check.company,
+            this.check.busStop,
+            this.check.route,
+            this.check.dir,
+            this.check.serviceType,
+            this.lang
+          );
+          allEtas.push(...obj.etas);
+        } catch (error) {
+          console.log(error);
+        }
+
+        // sort by route
+        this.res.etas = _.sortBy(allEtas, [
+          function (e) {
+            return extractNumber(e.route);
+          },
+          "route",
+          "eta_seq",
+        ]);
       }
-
-      // sort by route
-      this.res.etas = _.sortBy(allEtas, [
-        function (e) {
-          return extractNumber(e.route);
-        },
-        "route",
-        "eta_seq",
-      ]);
 
       this.isLoading = false;
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,9 +41,6 @@ const app = {
     };
   },
   methods: {
-    getSettingsFromStorage() {
-      return readSettingsFromStorage();
-    },
     readSettings() {
       const settings = readSettingsFromStorage();
       if (settings) {
@@ -55,7 +52,9 @@ const app = {
       }
     },
     async updateSettings(setting) {
-      console.log("Saving setting");
+      console.log("Settings saved");
+
+      // update dashboard data
       this.check.company = setting.company;
       this.check.busStop = setting.busStop;
       this.check.route = setting.route;
@@ -197,10 +196,7 @@ export default app;
           </template>
         </div>
       </div>
-      <StationSettings
-        :settings="this.getSettingsFromStorage()"
-        @update-settings="updateSettings"
-      />
+      <StationSettings @update-settings="updateSettings" />
     </div>
   </div>
 </template>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -1,0 +1,203 @@
+<script>
+import { extractNumber, getEtaByCompany } from "../eta";
+
+export default {
+  props: ["title"],
+  emits: ["updateSetting"],
+  data() {
+    return {
+      count: 0,
+      modalOpen: false,
+      selected: {
+        company: null,
+        route: null,
+        dir: null,
+        serviceType: null,
+        stop: null,
+      },
+      routeDirServiceType: null,
+      companyList: [
+        { code: "KMB", name: "Kowloon Motor Bus" },
+        { code: "NLB", name: "New Lantao Bus" },
+      ],
+      routeList: [],
+      stopList: [],
+    };
+  },
+  watch: {
+    "selected.company"(newValue, oldValue) {
+      if (!!newValue) {
+        this.getAllRoutes(newValue);
+      }
+    },
+    routeDirServiceType(newValue, oldValue) {
+      if (!!newValue) {
+        const arr = newValue.split("|");
+        this.selected.route = arr[0];
+        this.selected.dir = this.getDirection(arr[1]);
+        this.selected.serviceType = arr[2];
+
+        this.getAllStops(
+          this.selected.company,
+          this.selected.route,
+          this.selected.dir,
+          this.selected.serviceType
+        );
+      }
+    },
+  },
+  methods: {
+    saveSettings() {
+      const e = {
+        company: this.selected.company,
+        route: this.selected.route,
+        dir: this.selected.dir,
+        serviceType: this.selected.serviceType,
+        stop: this.selected.stop,
+      };
+      this.$emit("updateSetting", e);
+    },
+    getDirection(d) {
+      switch (d) {
+        case "I":
+          return "inbound";
+        case "O":
+          return "outbound";
+        default:
+          return "";
+      }
+    },
+    async getAllRoutes(company) {
+      let routes = [];
+      try {
+        routes = await getEtaByCompany(company).getRoutes();
+      } catch (error) {
+        console.log("Cannot get all routes");
+      }
+      this.routeList = routes;
+    },
+    async getAllStops(company, route, dir, serviceType) {
+      let routeStops = [];
+      try {
+        const stops = await getEtaByCompany(company).getStops();
+        const routeStopsSimple = await getEtaByCompany(company).getRouteStops(
+          route,
+          dir,
+          serviceType
+        );
+        routeStops = routeStopsSimple.map((s) => {
+          const stopName = stops.find((stop) => stop.stop === s.stop);
+          return {
+            ...s,
+            name_en: stopName.name_en,
+            name_tc: stopName.name_tc,
+            name_sc: stopName.name_sc,
+          };
+        });
+      } catch (error) {
+        console.log(error);
+        console.log("Cannot get all stops in the route");
+      }
+      this.stopList = routeStops;
+    },
+  },
+};
+</script>
+
+<template>
+  <!-- <h1 style="color: var(--color-text)">{{ msg }}</h1> -->
+
+  <div class="card" style="color: var(--color-text)">
+    <button type="button" @click="modalOpen = true">Open Settings</button>
+  </div>
+  <teleport to="body">
+    <div
+      v-if="modalOpen"
+      id="modal"
+      class="modal fixed inset-0 overflow-y-auto"
+    >
+      <div class="flex justify-center items-center h-screen">
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-1/2">
+          <div class="mb-4">
+            <h2 class="text-xl font-bold">{{ title }}</h2>
+          </div>
+          <div class="mb-4">
+            <p>Modal content goes here.</p>
+          </div>
+          <div class="mb-6">
+            <div class="grid grid-cols-1 md:grid-cols-6">
+              <div>Company</div>
+              <div class="md:col-start-2 md:col-span-5">
+                <select v-model="selected.company">
+                  <option
+                    v-for="company of companyList"
+                    v-bind:key="company.code"
+                    v-bind:value="company.code"
+                  >
+                    {{ company.name }}
+                  </option>
+                </select>
+              </div>
+
+              <div>Route (To)</div>
+              <div class="md:col-start-2 md:col-span-5">
+                <select v-model="routeDirServiceType">
+                  <option
+                    v-for="route of routeList"
+                    v-bind:key="route.route + route.bound + route.service_type"
+                    v-bind:value="
+                      route.route + '|' + route.bound + '|' + route.service_type
+                    "
+                  >
+                    {{ route.route }} - {{ route.dest_en }}
+                  </option>
+                </select>
+              </div>
+
+              <div>Stop</div>
+              <div class="md:col-start-2 md:col-span-5">
+                <select v-model="selected.stop">
+                  <option
+                    v-for="stop of stopList"
+                    v-bind:key="stop.stop"
+                    v-bind:value="stop.stop"
+                  >
+                    {{ stop.name_en }}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="flex justify-end">
+            <button
+              class="bg-[var(--color-accent)] hover:bg-blue-700 font-bold py-2 px-4 mx-2 rounded"
+              style="color: var(--color-text)"
+              @click="
+                saveSettings();
+                modalOpen = false;
+              "
+            >
+              Save
+            </button>
+            <button
+              class="bg-[var(--color-accent)] hover:bg-blue-700 font-bold py-2 px-4 mx-2 rounded"
+              style="color: var(--color-text)"
+              @click="modalOpen = false"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<style scoped>
+.modal {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal div {
+}
+</style>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -100,8 +100,12 @@ export default {
         busStop: this.selected.busStop,
       };
 
-      // save to local storage
-      localStorage.setItem("settings", JSON.stringify(e));
+      try {
+        // save to local storage
+        localStorage.setItem("settings", JSON.stringify(e));
+      } catch (error) {
+        alert("Cannot persist settings information");
+      }
 
       // emit event to parent
       this.$emit("updateSettings", e);

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -6,7 +6,8 @@ export default {
   emits: ["updateSetting"],
   data() {
     return {
-      count: 0,
+      message: "Please choose the bus company, bus route and bus stop.",
+      error: "",
       modalOpen: false,
       selected: {
         company: null,
@@ -48,6 +49,19 @@ export default {
   },
   methods: {
     saveSettings() {
+      if (
+        this.selected.company == null ||
+        this.selected.route == null ||
+        this.selected.dir == null ||
+        this.selected.serviceType == null ||
+        this.selected.stop == null
+      ) {
+        this.error = "Please select the values!";
+        return;
+      } else {
+        this.error = "";
+      }
+
       const e = {
         company: this.selected.company,
         route: this.selected.route,
@@ -55,7 +69,9 @@ export default {
         serviceType: this.selected.serviceType,
         stop: this.selected.stop,
       };
+
       this.$emit("updateSetting", e);
+      this.modalOpen = false;
     },
     getDirection(d) {
       switch (d) {
@@ -105,10 +121,8 @@ export default {
 </script>
 
 <template>
-  <!-- <h1 style="color: var(--color-text)">{{ msg }}</h1> -->
-
-  <div class="card" style="color: var(--color-text)">
-    <button type="button" @click="modalOpen = true">Open Settings</button>
+  <div class="card text-right" style="color: var(--color-primary)">
+    <button type="button" @click="modalOpen = true">Settings</button>
   </div>
   <teleport to="body">
     <div
@@ -117,18 +131,25 @@ export default {
       class="modal fixed inset-0 overflow-y-auto"
     >
       <div class="flex justify-center items-center h-screen">
-        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-1/2">
+        <div
+          class="bg-[var(--color-bg)] shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96 md:w-2/3"
+          style="color: var(--color-primary)"
+        >
           <div class="mb-4">
             <h2 class="text-xl font-bold">{{ title }}</h2>
           </div>
           <div class="mb-4">
-            <p>Modal content goes here.</p>
+            <p>{{ message }}</p>
           </div>
           <div class="mb-6">
-            <div class="grid grid-cols-1 md:grid-cols-6">
-              <div>Company</div>
+            <div class="grid grid-cols-1 md:grid-cols-6 gap-4">
+              <div>Bus Company:</div>
               <div class="md:col-start-2 md:col-span-5">
-                <select v-model="selected.company">
+                <select
+                  v-model="selected.company"
+                  style="color: var(--color-bg)"
+                >
+                  <option />
                   <option
                     v-for="company of companyList"
                     v-bind:key="company.code"
@@ -139,9 +160,13 @@ export default {
                 </select>
               </div>
 
-              <div>Route (To)</div>
+              <div>Bus Route (To):</div>
               <div class="md:col-start-2 md:col-span-5">
-                <select v-model="routeDirServiceType">
+                <select
+                  v-model="routeDirServiceType"
+                  style="color: var(--color-bg)"
+                >
+                  <option />
                   <option
                     v-for="route of routeList"
                     v-bind:key="route.route + route.bound + route.service_type"
@@ -154,9 +179,10 @@ export default {
                 </select>
               </div>
 
-              <div>Stop</div>
+              <div>Bus Stop:</div>
               <div class="md:col-start-2 md:col-span-5">
-                <select v-model="selected.stop">
+                <select v-model="selected.stop" style="color: var(--color-bg)">
+                  <option />
                   <option
                     v-for="stop of stopList"
                     v-bind:key="stop.stop"
@@ -168,14 +194,18 @@ export default {
               </div>
             </div>
           </div>
+          <div
+            class="mb-4"
+            style="color: var(--color-secondary)"
+            v-show="error"
+          >
+            <p>{{ error }}</p>
+          </div>
           <div class="flex justify-end">
             <button
               class="bg-[var(--color-accent)] hover:bg-blue-700 font-bold py-2 px-4 mx-2 rounded"
               style="color: var(--color-text)"
-              @click="
-                saveSettings();
-                modalOpen = false;
-              "
+              @click="saveSettings()"
             >
               Save
             </button>
@@ -195,9 +225,6 @@ export default {
 
 <style scoped>
 .modal {
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
-.modal div {
+  background-color: rgba(0, 0, 0, 0.8);
 }
 </style>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -263,6 +263,6 @@ export default {
 
 <style scoped>
 .modal {
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: rgba(255, 255, 255, 0.6);
 }
 </style>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -1,10 +1,7 @@
 <script>
-import { getEtaByCompany } from "../eta";
+import { getEtaByCompany, readSettingsFromStorage } from "../eta";
 
 export default {
-  props: {
-    settings: Object,
-  },
   emits: ["updateSettings"],
   data() {
     return {
@@ -12,17 +9,13 @@ export default {
       error: "",
       modalOpen: false,
       selected: {
-        company: this.settings?.company || "",
-        route: this.settings?.route || "",
-        dir: this.settings?.dir || "",
-        serviceType: this.settings?.serviceType || "",
-        busStop: this.settings?.busStop || "",
+        company: "",
+        route: "",
+        dir: "",
+        serviceType: "",
+        busStop: "",
       },
-      routeDirServiceType: this.joinRouteDirServiceType(
-        this.settings?.route || "",
-        this.settings?.dir || "",
-        this.settings?.serviceType || ""
-      ),
+      routeDirServiceType: "",
       companyList: [
         { code: "KMB", name: "Kowloon Motor Bus" },
         { code: "NLB", name: "New Lantao Bus" },
@@ -37,6 +30,15 @@ export default {
       handler(newValue, oldValue) {
         if (!!newValue) {
           this.getAllRoutes(newValue);
+        }
+
+        if (!!oldValue) {
+          // clear current selected route and bus stop
+          this.routeDirServiceType = "";
+          this.selected.route = "";
+          this.selected.dir = "";
+          this.selected.serviceType = "";
+          this.selected.busStop = "";
         }
       },
     },
@@ -55,6 +57,11 @@ export default {
             this.selected.dir,
             this.selected.serviceType
           );
+        }
+
+        if (!!oldValue) {
+          // clear current selected stop
+          this.selected.busStop = "";
         }
       },
     },
@@ -102,6 +109,27 @@ export default {
       // close modal
       this.modalOpen = false;
     },
+    openSettings() {
+      const settings = readSettingsFromStorage();
+
+      // init from settings
+      this.selected.company = settings?.company || "";
+      this.selected.route = settings?.route || "";
+      this.selected.dir = settings?.dir || "";
+      this.selected.serviceType = settings?.serviceType || "";
+      this.selected.busStop = settings?.busStop || "";
+      this.routeDirServiceType = this.joinRouteDirServiceType(
+        settings?.route || "",
+        settings?.dir || "",
+        settings?.serviceType || ""
+      );
+
+      this.modalOpen = true;
+    },
+    closeSettings() {
+      this.error = "";
+      this.modalOpen = false;
+    },
     async getAllRoutes(company) {
       let routes = [];
       try {
@@ -132,7 +160,7 @@ export default {
 
 <template>
   <div style="color: var(--color-primary)">
-    <button type="button" @click="modalOpen = true">Settings</button>
+    <button type="button" @click="openSettings()">Settings</button>
   </div>
   <teleport to="body">
     <div
@@ -231,7 +259,7 @@ export default {
             <button
               class="bg-[var(--color-accent)] hover:bg-[var(--color-secondary)] font-bold py-2 px-4 mx-2 rounded"
               style="color: var(--color-text)"
-              @click="modalOpen = false"
+              @click="closeSettings()"
             >
               Close
             </button>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -56,7 +56,7 @@ export default {
         this.selected.serviceType == null ||
         this.selected.stop == null
       ) {
-        this.error = "Please select the values!";
+        this.error = "Please select values!";
         return;
       } else {
         this.error = "";
@@ -121,7 +121,7 @@ export default {
 </script>
 
 <template>
-  <div class="card text-right" style="color: var(--color-primary)">
+  <div style="color: var(--color-primary)">
     <button type="button" @click="modalOpen = true">Settings</button>
   </div>
   <teleport to="body">
@@ -132,7 +132,7 @@ export default {
     >
       <div class="flex justify-center items-center h-screen">
         <div
-          class="bg-[var(--color-bg)] shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96 md:w-2/3"
+          class="bg-[var(--color-bg)] shadow-md border-solid border-2 border-emerald-500 rounded px-8 pt-6 pb-6 w-96 md:w-2/3"
           style="color: var(--color-primary)"
         >
           <div class="mb-4">
@@ -143,9 +143,10 @@ export default {
           </div>
           <div class="mb-6">
             <div class="grid grid-cols-1 md:grid-cols-6 gap-4">
-              <div>Bus Company:</div>
+              <div><label for="company">Bus Company:</label></div>
               <div class="md:col-start-2 md:col-span-5">
                 <select
+                  name="company"
                   v-model="selected.company"
                   style="color: var(--color-bg)"
                 >
@@ -160,9 +161,12 @@ export default {
                 </select>
               </div>
 
-              <div>Bus Route (To):</div>
+              <div>
+                <label for="routeDirServiceType">Bus Route (To):</label>
+              </div>
               <div class="md:col-start-2 md:col-span-5">
                 <select
+                  name="routeDirServiceType"
                   v-model="routeDirServiceType"
                   style="color: var(--color-bg)"
                 >
@@ -179,9 +183,13 @@ export default {
                 </select>
               </div>
 
-              <div>Bus Stop:</div>
+              <div><label for="busStop">Bus Stop:</label></div>
               <div class="md:col-start-2 md:col-span-5">
-                <select v-model="selected.stop" style="color: var(--color-bg)">
+                <select
+                  name="busStop"
+                  v-model="selected.stop"
+                  style="color: var(--color-bg)"
+                >
                   <option />
                   <option
                     v-for="stop of stopList"
@@ -203,14 +211,14 @@ export default {
           </div>
           <div class="flex justify-end">
             <button
-              class="bg-[var(--color-accent)] hover:bg-blue-700 font-bold py-2 px-4 mx-2 rounded"
+              class="bg-[var(--color-accent)] hover:bg-[var(--color-secondary)] font-bold py-2 px-4 mx-2 rounded"
               style="color: var(--color-text)"
               @click="saveSettings()"
             >
               Save
             </button>
             <button
-              class="bg-[var(--color-accent)] hover:bg-blue-700 font-bold py-2 px-4 mx-2 rounded"
+              class="bg-[var(--color-accent)] hover:bg-[var(--color-secondary)] font-bold py-2 px-4 mx-2 rounded"
               style="color: var(--color-text)"
               @click="modalOpen = false"
             >

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -12,16 +12,16 @@ export default {
       error: "",
       modalOpen: false,
       selected: {
-        company: this.settings.company || "",
-        route: this.settings.route || "",
-        dir: this.settings.dir || "",
-        serviceType: this.settings.serviceType || "",
-        busStop: this.settings.busStop || "",
+        company: this.settings?.company || "",
+        route: this.settings?.route || "",
+        dir: this.settings?.dir || "",
+        serviceType: this.settings?.serviceType || "",
+        busStop: this.settings?.busStop || "",
       },
       routeDirServiceType: this.joinRouteDirServiceType(
-        this.settings.route || "",
-        this.settings.dir || "",
-        this.settings.serviceType || ""
+        this.settings?.route || "",
+        this.settings?.dir || "",
+        this.settings?.serviceType || ""
       ),
       companyList: [
         { code: "KMB", name: "Kowloon Motor Bus" },

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -46,7 +46,7 @@ export default {
         if (!!newValue) {
           const arr = newValue.split("|");
           this.selected.route = arr[0];
-          this.selected.dir = this.transformDirection(arr[1] || "");
+          this.selected.dir = arr[1] || "";
           this.selected.serviceType = arr[2] || "";
 
           this.getAllStops(
@@ -66,7 +66,7 @@ export default {
         arr.push(route);
       }
       if (dir) {
-        arr.push(this.transformDirectionReverse(dir));
+        arr.push(dir);
       }
       if (serviceType) {
         arr.push(serviceType);
@@ -101,28 +101,6 @@ export default {
 
       // close modal
       this.modalOpen = false;
-    },
-    transformDirection(d) {
-      switch (d) {
-        case "I":
-          return "inbound";
-        case "O":
-          return "outbound";
-        default:
-          // return unchanged value
-          return d;
-      }
-    },
-    transformDirectionReverse(d) {
-      switch (d) {
-        case "inbound":
-          return "I";
-        case "outbound":
-          return "O";
-        default:
-          // return unchanged value
-          return d;
-      }
     },
     async getAllRoutes(company) {
       let routes = [];
@@ -180,6 +158,7 @@ export default {
                 <select
                   name="company"
                   v-model="selected.company"
+                  class="dropdown"
                   style="color: var(--color-bg)"
                 >
                   <option value>Please choose</option>
@@ -200,6 +179,7 @@ export default {
                 <select
                   name="routeDirServiceType"
                   v-model="routeDirServiceType"
+                  class="dropdown"
                   style="color: var(--color-bg)"
                 >
                   <option value>Please choose</option>
@@ -218,12 +198,13 @@ export default {
                 <select
                   name="busStop"
                   v-model="selected.busStop"
+                  class="dropdown"
                   style="color: var(--color-bg)"
                 >
                   <option value>Please choose</option>
                   <option
                     v-for="stop of stopList"
-                    v-bind:key="stop.stop"
+                    v-bind:key="stop.stop + '|' + stop.seq"
                     v-bind:value="stop.stop"
                   >
                     {{ stop.name_en }}
@@ -264,5 +245,9 @@ export default {
 <style scoped>
 .modal {
   background-color: rgba(255, 255, 255, 0.6);
+}
+
+.dropdown {
+  max-width: 100%;
 }
 </style>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -35,8 +35,8 @@ export default {
       if (!!newValue) {
         const arr = newValue.split("|");
         this.selected.route = arr[0];
-        this.selected.dir = this.getDirection(arr[1]);
-        this.selected.serviceType = arr[2];
+        this.selected.dir = this.getDirection(arr[1] || "1");
+        this.selected.serviceType = arr[2] || "";
 
         this.getAllStops(
           this.selected.company,
@@ -96,20 +96,11 @@ export default {
       let routeStops = [];
       try {
         const stops = await getEtaByCompany(company).getStops();
-        const routeStopsSimple = await getEtaByCompany(company).getRouteStops(
+        routeStops = await getEtaByCompany(company).getRouteStops(
           route,
           dir,
           serviceType
         );
-        routeStops = routeStopsSimple.map((s) => {
-          const stopName = stops.find((stop) => stop.stop === s.stop);
-          return {
-            ...s,
-            name_en: stopName.name_en,
-            name_tc: stopName.name_tc,
-            name_sc: stopName.name_sc,
-          };
-        });
       } catch (error) {
         console.log(error);
         console.log("Cannot get all stops in the route");
@@ -173,10 +164,8 @@ export default {
                   <option />
                   <option
                     v-for="route of routeList"
-                    v-bind:key="route.route + route.bound + route.service_type"
-                    v-bind:value="
-                      route.route + '|' + route.bound + '|' + route.service_type
-                    "
+                    v-bind:key="route.routeId"
+                    v-bind:value="route.routeId"
                   >
                     {{ route.route }} - {{ route.dest_en }}
                   </option>

--- a/src/eta-kmb.js
+++ b/src/eta-kmb.js
@@ -1,5 +1,17 @@
 import moment from "moment";
 
+function transformDirection(d) {
+  switch (d) {
+    case "I":
+      return "inbound";
+    case "O":
+      return "outbound";
+    default:
+      // return unchanged value
+      return d;
+  }
+}
+
 const etaKmb = {
   async getRoutes() {
     let res = null;
@@ -42,7 +54,9 @@ const etaKmb = {
 
   async getRoute(route, dir, serviceType) {
     let res = null;
-    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route/${route}/${dir}/${serviceType}`;
+    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route/${route}/${transformDirection(
+      dir
+    )}/${serviceType}`;
 
     try {
       const response = await fetch(url);
@@ -60,7 +74,9 @@ const etaKmb = {
     let res = null;
     const allStops = await this.getStops();
 
-    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route-stop/${route}/${dir}/${serviceType}`;
+    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route-stop/${route}/${transformDirection(
+      dir
+    )}/${serviceType}`;
 
     try {
       const response = await fetch(url);

--- a/src/eta-kmb.js
+++ b/src/eta-kmb.js
@@ -14,7 +14,6 @@ const etaKmb = {
       console.error(error);
       throw error;
     }
-    console.log(res);
     return res;
   },
 
@@ -43,7 +42,6 @@ const etaKmb = {
       const data = await response.json();
       console.log(data["generated_timestamp"]);
       res = data.data;
-      console.log(res);
     } catch (error) {
       console.error(error);
       throw error;

--- a/src/eta-kmb.js
+++ b/src/eta-kmb.js
@@ -1,9 +1,57 @@
 import moment from "moment";
 
 const etaKmb = {
+  async getRoutes() {
+    let res = null;
+    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route/`;
+
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+      console.log(data["generated_timestamp"]);
+      res = data.data;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+    return res;
+  },
+
+  async getStops() {
+    let res = null;
+    const url = `https://data.etabus.gov.hk/v1/transport/kmb/stop/`;
+
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+      console.log(data["generated_timestamp"]);
+      res = data.data;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+    return res;
+  },
+
   async getRoute(route, dir, serviceType) {
     let res = null;
     const url = `https://data.etabus.gov.hk/v1/transport/kmb/route/${route}/${dir}/${serviceType}`;
+
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+      console.log(data["generated_timestamp"]);
+      res = data.data;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+    return res;
+  },
+
+  async getRouteStops(route, dir, serviceType) {
+    let res = null;
+    const url = `https://data.etabus.gov.hk/v1/transport/kmb/route-stop/${route}/${dir}/${serviceType}`;
 
     try {
       const response = await fetch(url);
@@ -33,7 +81,7 @@ const etaKmb = {
     return res;
   },
 
-  async getEtas(busStop, route, dir, lang) {
+  async getEtas(busStop, route, dir, serviceType, lang) {
     let res = [];
     const url = `https://data.etabus.gov.hk/v1/transport/kmb/stop-eta/${busStop}`;
 
@@ -50,12 +98,13 @@ const etaKmb = {
       (o) =>
         o.route === route &&
         dir.toUpperCase().startsWith(o.dir.toUpperCase()) &&
+        serviceType === o.service_type + "" &&
         !!o.eta
     );
   },
 
-  async getEtaDisplay(busStop, route, dir, lang) {
-    const etas = await this.getEtas(busStop, route, dir, lang);
+  async getEtaDisplay(busStop, route, dir, serviceType, lang) {
+    const etas = await this.getEtas(busStop, route, dir, serviceType, lang);
     for (const eta of etas) {
       // format the eta time
       if (!!eta.eta) {

--- a/src/eta-kmb.js
+++ b/src/eta-kmb.js
@@ -9,7 +9,14 @@ const etaKmb = {
       const response = await fetch(url);
       const data = await response.json();
       console.log(data["generated_timestamp"]);
-      res = data.data;
+      // add routeId by combining
+      // route.route + '|' + route.bound + '|' + route.service_type
+      res = data.data.map((route) => {
+        return {
+          ...route,
+          routeId: route.route + "|" + route.bound + "|" + route.service_type,
+        };
+      });
     } catch (error) {
       console.error(error);
       throw error;
@@ -51,13 +58,25 @@ const etaKmb = {
 
   async getRouteStops(route, dir, serviceType) {
     let res = null;
+    const allStops = await this.getStops();
+
     const url = `https://data.etabus.gov.hk/v1/transport/kmb/route-stop/${route}/${dir}/${serviceType}`;
 
     try {
       const response = await fetch(url);
       const data = await response.json();
       console.log(data["generated_timestamp"]);
-      res = data.data;
+      const routeStops = data.data;
+
+      res = routeStops.map((s) => {
+        const stopName = allStops.find((stop) => stop.stop === s.stop);
+        return {
+          ...s,
+          name_en: stopName.name_en,
+          name_tc: stopName.name_tc,
+          name_sc: stopName.name_sc,
+        };
+      });
     } catch (error) {
       console.error(error);
       throw error;

--- a/src/eta-nlb.js
+++ b/src/eta-nlb.js
@@ -2,6 +2,14 @@ import moment from "moment";
 import { NLB_STOPS } from "./nlb";
 
 const etaNlb = {
+  async getRoutes() {
+    return [];
+  },
+
+  async getStops() {
+    return [];
+  },
+
   async getRoute(route, dir, serviceType) {
     let res = null;
 
@@ -61,7 +69,11 @@ const etaNlb = {
     }
   },
 
-  async getEtas(busStop, route, dir, lang) {
+  async getRouteStops() {
+    return [];
+  },
+
+  async getEtas(busStop, route, dir, serviceType, lang) {
     let res = [];
     const url = `https://rt.data.gov.hk/v2/transport/nlb/stop.php?action=estimatedArrivals&routeId=${route}&stopId=${busStop}&language=en`;
 
@@ -102,8 +114,8 @@ const etaNlb = {
     return res;
   },
 
-  async getEtaDisplay(busStop, route, dir, lang) {
-    const etas = await this.getEtas(busStop, route, dir, lang);
+  async getEtaDisplay(busStop, route, dir, serviceType, lang) {
+    const etas = await this.getEtas(busStop, route, dir, serviceType, lang);
     for (const eta of etas) {
       // format the eta time
       if (!!eta.eta) {

--- a/src/eta-nlb.js
+++ b/src/eta-nlb.js
@@ -3,11 +3,49 @@ import { NLB_STOPS } from "./nlb";
 
 const etaNlb = {
   async getRoutes() {
-    return [];
+    let res = null;
+
+    // get API URL
+    const url = `https://rt.data.gov.hk/v2/transport/nlb/route.php?action=list`;
+
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+
+      // filter from a full list of routes
+      res = data.routes.map((routeInfo) => {
+        return {
+          routeId: routeInfo.routeId,
+          route: routeInfo.routeNo,
+          bound: "",
+          service_type: "",
+          orig_en: routeInfo.routeName_e.split(">")[0]?.trim(),
+          orig_tc: routeInfo.routeName_c.split(">")[0]?.trim(),
+          orig_sc: routeInfo.routeName_s.split(">")[0]?.trim(),
+          dest_en: routeInfo.routeName_e.split(">")[1]?.trim(),
+          dest_tc: routeInfo.routeName_c.split(">")[1]?.trim(),
+          dest_sc: routeInfo.routeName_s.split(">")[1]?.trim(),
+        };
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+
+    return res;
   },
 
   async getStops() {
-    return [];
+    return NLB_STOPS.map((stop) => {
+      return {
+        stop: stop.stopId,
+        name_en: stop.stopName_e,
+        name_tc: stop.stopName_c,
+        name_sc: stop.stopName_s,
+        lat: stop.latitude,
+        long: stop.longitude,
+      };
+    });
   },
 
   async getRoute(route, dir, serviceType) {
@@ -31,6 +69,7 @@ const etaNlb = {
       // KMB: {"route":"1","bound":"I","service_type":"1","orig_en":"STAR FERRY","orig_tc":"尖沙咀碼頭","orig_sc":"尖沙咀码头","dest_en":"CHUK YUEN ESTATE","dest_tc":"竹園邨","dest_sc":"竹园邨"}
 
       res = {
+        routeId: routeInfo.routeId,
         route: routeInfo.routeNo,
         bound: "",
         service_type: "",
@@ -45,6 +84,7 @@ const etaNlb = {
       console.error(error);
       throw error;
     }
+
     return res;
   },
 
@@ -69,8 +109,35 @@ const etaNlb = {
     }
   },
 
-  async getRouteStops() {
-    return [];
+  async getRouteStops(route, dir, serviceType) {
+    let res = null;
+
+    // get API URL
+    const url = `https://rt.data.gov.hk/v2/transport/nlb/stop.php?action=list&routeId=${route}`;
+
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+
+      // convert data to KMB style
+      res = data.stops.map((stop, index) => {
+        return {
+          stop: stop.stopId,
+          route: stop.route,
+          bound: "",
+          service_type: "",
+          seq: index,
+          name_en: stop.stopName_e.split(">")[0]?.trim(),
+          name_tc: stop.stopName_c.split(">")[0]?.trim(),
+          name_sc: stop.stopName_s.split(">")[0]?.trim(),
+        };
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+
+    return res;
   },
 
   async getEtas(busStop, route, dir, serviceType, lang) {

--- a/src/eta.js
+++ b/src/eta.js
@@ -16,3 +16,12 @@ export function extractNumber(route) {
   const num = route.replace(/[^0-9]/g, "");
   return parseInt(num != null ? num : route);
 }
+
+export function readSettingsFromStorage() {
+  const settingsStr = localStorage.getItem("settings");
+  if (settingsStr) {
+    return JSON.parse(settingsStr);
+  } else {
+    return null;
+  }
+}

--- a/src/eta.js
+++ b/src/eta.js
@@ -18,10 +18,14 @@ export function extractNumber(route) {
 }
 
 export function readSettingsFromStorage() {
-  const settingsStr = localStorage.getItem("settings");
-  if (settingsStr) {
-    return JSON.parse(settingsStr);
-  } else {
-    return null;
+  try {
+    const settingsStr = localStorage.getItem("settings");
+    if (settingsStr) {
+      return JSON.parse(settingsStr);
+    } else {
+      return null;
+    }
+  } catch (error) {
+    alert("Cannot read settings information!");
   }
 }


### PR DESCRIPTION
Add settings modal and persist settings:
- Users are now allowed to choose a special bus company, bus route and bus stop for the dashboard
- The selected values will be stored in `localStorage` so that the settings will be used when the page is opened again

---

![image](https://user-images.githubusercontent.com/7422410/230843911-fb7dbbf8-c202-449d-adb0-11da1d4e74a0.png)
