### PR TITLE
Mobile bottom sheet, disabled loading dropdowns, and desktop overflow-visible modal

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -1,0 +1,159 @@
+# Bottom Sheet Pattern on Mobile
+
+## What is a Bottom Sheet?
+
+A **bottom sheet** is a UI panel that slides up from the bottom of the screen. It's a common mobile pattern used by Google Maps, Apple Maps, Uber, and most modern mobile apps. It replaces inline dropdowns and modals on small screens where they tend to cause scroll conflicts and are hard to interact with.
+
+## Why We Used It
+
+The original `SearchableSelect` component used an **inline dropdown** (absolutely positioned below the input). On mobile, this caused problems:
+
+- **Scroll conflicts** — scrolling the dropdown list would scroll the page behind it
+- **Accidental selection** — `@pointerdown.prevent` was used to prevent blur-on-click, but it also made scroll gestures trigger selection
+- **Keyboard overlap** — when the search input was focused, the virtual keyboard covered the dropdown options
+- **Small touch targets** — dropdown items were too small to tap reliably
+
+The bottom sheet solves all of these by taking over the full screen.
+
+## Implementation
+
+### Dual-mode Component
+
+The `SearchableSelect.vue` component renders differently based on screen width:
+
+```
+Desktop (≥768px) → Inline dropdown (absolute positioned below input)
+Mobile  (<768px) → Full-screen bottom sheet (teleported to <body>)
+```
+
+### Key Code Patterns
+
+#### 1. Screen Detection
+
+```ts
+const isMobile = ref(false);
+
+function checkMobile() {
+    isMobile.value = window.innerWidth < 768;
+}
+
+onMounted(() => {
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+});
+```
+
+#### 2. Teleport to `<body>`
+
+The bottom sheet is teleported outside the component tree to avoid being clipped by parent `overflow` or `z-index` stacking contexts:
+
+```html
+<teleport to="body">
+    <div v-if="isOpen && isMobile" class="fixed inset-0 z-[100]">
+        <!-- backdrop + sheet content -->
+    </div>
+</teleport>
+```
+
+#### 3. Body Scroll Lock
+
+When the sheet is open, the background page must not scroll:
+
+```ts
+watch(isOpen, (val) => {
+    if (val && isMobile.value) {
+        document.body.style.overflow = "hidden";
+    } else if (isMobile.value) {
+        document.body.style.overflow = "";
+    }
+});
+```
+
+#### 4. Touch Scroll Containment
+
+The options list uses `overscroll-contain` to prevent scroll chaining (where scrolling past the end of the list would scroll the page behind it):
+
+```html
+<div class="overflow-y-auto overscroll-contain">
+    <!-- options -->
+</div>
+```
+
+#### 5. Readonly Input on Mobile
+
+On mobile, the trigger input is `readonly` so tapping it opens the bottom sheet instead of the keyboard. The sheet has its own search input:
+
+```html
+<input :readonly="isMobile" @click="open" />
+```
+
+#### 6. Touch-Friendly Targets
+
+Each option has a minimum height of 44px (Apple's recommended minimum touch target size):
+
+```html
+<div style="min-height: 44px; display: flex; align-items: center;">
+    {{ option.label }}
+</div>
+```
+
+#### 7. Safe Area Insets
+
+For phones with notches or gesture bars, the list respects the safe area:
+
+```html
+<div class="pb-[env(safe-area-inset-bottom,1rem)]">
+```
+
+## Structure
+
+```
+┌──────────────────────────┐
+│      Dark Backdrop       │  ← @click="close"
+│  ┌────────────────────┐  │
+│  │    ── Handle ──    │  │  ← Visual affordance
+│  │  ┌──────────────┐  │  │
+│  │  │ Search input  │  │  │  ← Auto-focused, inputmode="search"
+│  │  └──────────────┘  │  │
+│  │  ┌──────────────┐  │  │
+│  │  │ Option 1     │  │  │  ← 44px min-height
+│  │  │ Option 2 ✓   │  │  │  ← Selected highlight
+│  │  │ Option 3     │  │  │
+│  │  │ ...          │  │  │  ← Scrollable, overscroll-contain
+│  │  └──────────────┘  │  │
+│  └────────────────────┘  │
+└──────────────────────────┘
+```
+
+## Gotchas & Lessons Learned
+
+### 1. `flex-1` needs `min-h-0`
+In a flex column layout, `flex-1` children don't shrink below their content size by default. You need `min-h-0` on the parent for `overflow-y-auto` to work on the child.
+
+### 2. Backdrop steals touch events
+An `absolute inset-0` backdrop sits on top of sibling content. The sheet needs `z-10` (or higher) to receive touch events above the backdrop.
+
+### 3. Android Autofill Bar
+Android shows an autofill suggestion bar (key, credit card, location icons) above the keyboard. Suppress it with:
+```html
+<input inputmode="search" autocomplete="off" />
+```
+
+### 4. `@pointerdown.prevent` breaks scrolling
+Using `@pointerdown.prevent` on list items prevents the browser's default scroll behavior. Use `@click` instead on mobile — it doesn't interfere with scrolling.
+
+### 5. IDE auto-formatter vs ESLint
+The formatter may convert `<input>` to `<input />` (self-closing), conflicting with `vue/html-self-closing`. Disable the rule if the formatter wins:
+```js
+rules: { "vue/html-self-closing": "off" }
+```
+
+## References
+
+- [Material Design — Bottom Sheets](https://m3.material.io/components/bottom-sheets/overview)
+- [Apple HIG — Sheets](https://developer.apple.com/design/human-interface-guidelines/sheets)
+- [MDN — Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API)
+- [MDN — overscroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior)
+- [MDN — env() safe-area-inset](https://developer.mozilla.org/en-US/docs/Web/CSS/env)
+- [Vue — Teleport](https://vuejs.org/guide/built-ins/teleport)
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ It also makes use of a static TypeScript file (`nlb.ts`) that contains all the b
 - **Loading indicator** while fetching arrival data
 - **Last-updated timestamp** with manual refresh button
 - **Searchable dropdowns** for bus company, route, and stop selection with keyboard navigation
-- **Loading spinners** on dropdowns while fetching routes and stops
+- **Loading spinners** on dropdowns while fetching routes and stops (dropdowns disabled during loading)
+- **Mobile bottom sheet** for dropdown selection with full-screen overlay, search input, and touch-friendly targets
+- **Desktop inline dropdown** with overflow-visible modal so options expand beyond the settings panel
 - **Dark theme** with persistent settings via localStorage
 - **Responsive layout** for desktop and mobile
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default tseslint.config(
         rules: {
             "vue/multi-word-component-names": "off",
             "vue/html-indent": "off",
+            "vue/html-self-closing": "off",
         },
     }
 );

--- a/src/components/SearchableSelect.vue
+++ b/src/components/SearchableSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 
 export interface SelectOption {
     value: string;
@@ -22,6 +22,21 @@ const isOpen = ref(false);
 const highlightIndex = ref(-1);
 const containerRef = ref<HTMLElement | null>(null);
 const listRef = ref<HTMLElement | null>(null);
+const sheetSearchRef = ref<HTMLInputElement | null>(null);
+const isMobile = ref(false);
+
+function checkMobile() {
+    isMobile.value = window.innerWidth < 768;
+}
+
+onMounted(() => {
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+});
+
+onUnmounted(() => {
+    window.removeEventListener("resize", checkMobile);
+});
 
 const selectedLabel = computed(() => {
     const found = props.options.find((o) => o.value === props.modelValue);
@@ -45,11 +60,23 @@ watch(isOpen, (val) => {
     if (val) {
         searchText.value = "";
         highlightIndex.value = -1;
+        if (isMobile.value) {
+            document.body.style.overflow = "hidden";
+            nextTick(() => sheetSearchRef.value?.focus());
+        }
+    } else if (isMobile.value) {
+        document.body.style.overflow = "";
     }
 });
 
 function open() {
+    if (props.loading) return;
     isOpen.value = true;
+}
+
+function close() {
+    isOpen.value = false;
+    searchText.value = "";
 }
 
 function selectOption(option: SelectOption) {
@@ -59,6 +86,7 @@ function selectOption(option: SelectOption) {
 }
 
 function onBlur(e: FocusEvent) {
+    if (isMobile.value) return;
     if (
         containerRef.value &&
         e.relatedTarget instanceof Node &&
@@ -66,8 +94,7 @@ function onBlur(e: FocusEvent) {
     ) {
         return;
     }
-    isOpen.value = false;
-    searchText.value = "";
+    close();
 }
 
 function scrollToHighlighted() {
@@ -109,8 +136,7 @@ function onKeydown(e: KeyboardEvent) {
             }
             break;
         case "Escape":
-            isOpen.value = false;
-            searchText.value = "";
+            close();
             break;
     }
 }
@@ -122,14 +148,19 @@ function onKeydown(e: KeyboardEvent) {
         class="searchable-select relative"
         @focusout="onBlur"
     >
+        <!-- Trigger input -->
         <div class="relative">
             <input
                 type="text"
                 class="dropdown w-full pr-8"
+                :class="{ 'opacity-50 cursor-not-allowed': loading }"
                 :placeholder="placeholder ?? 'Search...'"
-                :value="isOpen ? searchText : selectedLabel"
-                @input="searchText = ($event.target as HTMLInputElement).value"
+                :value="isOpen && !isMobile ? searchText : selectedLabel"
+                :disabled="loading"
+                :readonly="isMobile"
+                @click="open"
                 @focus="open"
+                @input="searchText = ($event.target as HTMLInputElement).value"
                 @keydown="onKeydown"
             />
             <!-- Loading spinner -->
@@ -173,11 +204,12 @@ function onKeydown(e: KeyboardEvent) {
                 />
             </svg>
         </div>
+
+        <!-- Desktop: inline dropdown -->
         <div
-            v-if="isOpen"
+            v-if="isOpen && !isMobile"
             ref="listRef"
-            class="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto overscroll-contain touch-pan-y rounded border border-[var(--color-primary)] bg-[var(--color-bg)]"
-            style="-webkit-overflow-scrolling: touch"
+            class="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto rounded border border-[var(--color-primary)] bg-[var(--color-bg)] text-[var(--color-text)]"
         >
             <div
                 v-if="filteredOptions.length === 0"
@@ -200,5 +232,79 @@ function onKeydown(e: KeyboardEvent) {
                 {{ option.label }}
             </div>
         </div>
+
+        <!-- Mobile: bottom sheet -->
+        <teleport to="body">
+            <div
+                v-if="isOpen && isMobile"
+                class="fixed inset-0 z-[100] flex flex-col"
+            >
+                <!-- Backdrop -->
+                <div
+                    class="absolute inset-0 bg-black/70"
+                    @click="close"
+                />
+
+                <!-- Sheet -->
+                <div
+                    class="relative z-10 flex-1 min-h-0 bg-[var(--color-bg)] text-[var(--color-text)] flex flex-col"
+                >
+                    <!-- Handle bar -->
+                    <div class="flex justify-center pt-3 pb-1">
+                        <div
+                            class="w-10 h-1 rounded-full bg-[var(--color-text)] opacity-30"
+                        />
+                    </div>
+
+                    <!-- Search input -->
+                    <div class="px-4 pb-3">
+                        <input
+                            ref="sheetSearchRef"
+                            type="text"
+                            inputmode="search"
+                            autocomplete="off"
+                            class="dropdown w-full"
+                            :placeholder="placeholder ?? 'Search...'"
+                            :value="searchText"
+                            @input="
+                                searchText = ($event.target as HTMLInputElement)
+                                    .value
+                            "
+                        />
+                    </div>
+
+                    <!-- Options list -->
+                    <div
+                        ref="listRef"
+                        class="flex-1 overflow-y-auto overscroll-contain px-2 pb-[env(safe-area-inset-bottom,1rem)]"
+                        style="-webkit-overflow-scrolling: touch"
+                    >
+                        <div
+                            v-if="filteredOptions.length === 0"
+                            class="px-3 py-4 text-sm opacity-50 text-center"
+                        >
+                            No results found
+                        </div>
+                        <div
+                            v-for="option in filteredOptions"
+                            :key="option.value"
+                            class="px-3 py-3 text-sm rounded-lg mb-1 active:bg-[var(--color-accent)] transition-colors"
+                            :class="{
+                                'bg-[var(--color-accent)]':
+                                    option.value === modelValue,
+                            }"
+                            style="
+                                min-height: 44px;
+                                display: flex;
+                                align-items: center;
+                            "
+                            @click="selectOption(option)"
+                        >
+                            {{ option.label }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </teleport>
     </div>
 </template>

--- a/src/components/StationSettings.vue
+++ b/src/components/StationSettings.vue
@@ -190,7 +190,7 @@ async function getAllStops(
                 class="flex justify-center items-center min-h-screen py-6 px-4"
             >
                 <div
-                    class="bg-[var(--color-bg)] shadow-md border-solid border-2 border-emerald-500 rounded px-8 pt-6 pb-6 w-96 md:w-2/3 max-h-[90vh] overflow-y-auto"
+                    class="bg-[var(--color-bg)] shadow-md border-solid border-2 border-emerald-500 rounded px-8 pt-6 pb-6 w-96 md:w-2/3 max-h-[90vh] overflow-y-auto md:overflow-visible"
                     style="color: var(--color-primary)"
                 >
                     <div class="mb-4">
@@ -204,7 +204,13 @@ async function getAllStops(
                     </div>
                     <div class="mb-6">
                         <div class="grid grid-cols-1 md:grid-cols-6 gap-4">
-                            <div><label for="company">Bus Company:</label></div>
+                            <div>
+                                <label
+                                    for="company"
+                                    class="opacity-70"
+                                    >Bus Company:</label
+                                >
+                            </div>
                             <div class="md:col-start-2 md:col-span-5">
                                 <SearchableSelect
                                     v-model="selected.company"
@@ -214,7 +220,9 @@ async function getAllStops(
                             </div>
 
                             <div>
-                                <label for="routeDirServiceType"
+                                <label
+                                    for="routeDirServiceType"
+                                    class="opacity-70"
                                     >Bus Route (To):</label
                                 >
                             </div>
@@ -227,7 +235,13 @@ async function getAllStops(
                                 />
                             </div>
 
-                            <div><label for="busStop">Bus Stop:</label></div>
+                            <div>
+                                <label
+                                    for="busStop"
+                                    class="opacity-70"
+                                    >Bus Stop:</label
+                                >
+                            </div>
                             <div class="md:col-start-2 md:col-span-5">
                                 <SearchableSelect
                                     v-model="selected.busStop"


### PR DESCRIPTION
## Summary

Replaces inline dropdowns with a full-screen bottom sheet on mobile for better touch interaction. Adds UX polish to the settings modal on both desktop and mobile.

## Changes

### Mobile Bottom Sheet
- Replace inline dropdown with a **full-screen bottom sheet** overlay on mobile (<768px)
- Teleport sheet to `<body>` to avoid parent clipping
- Pin search input at top with `inputmode="search"` and `autocomplete="off"` to suppress Android autofill bar
- 44px minimum touch targets for each option
- `overscroll-contain` to prevent scroll chaining
- `safe-area-inset-bottom` padding for notched phones
- Body scroll lock while sheet is open

### Desktop Dropdown
- Allow dropdown to **overflow outside the modal** (`md:overflow-visible`) instead of being clipped
- Input is editable for type-to-search on desktop, readonly on mobile

### Loading State
- **Disable dropdown interaction** while loading (spinner visible) — `disabled` attribute + `opacity-50 cursor-not-allowed`
- Guard `open()` function to prevent opening during loading

### Visual Polish
- Add `opacity-70` to setting labels ("Bus Company:", "Bus Route:", "Bus Stop:") for visual hierarchy against dropdown values

### Docs
- Update README Features section
- Add `LEARN.md` documenting the Bottom Sheet pattern

## Files Changed
- `src/components/SearchableSelect.vue` — bottom sheet, loading disable, readonly mobile
- `src/components/StationSettings.vue` — label opacity, overflow-visible modal
- `eslint.config.js` — disable `vue/html-self-closing` rule
- `README.md` — updated Features
- `LEARN.md` — new learning document